### PR TITLE
[Cherry-Pick][TVMScript] Parser int64 support (apache/tvm#10789)

### DIFF
--- a/python/tvm/script/tir/node.py
+++ b/python/tvm/script/tir/node.py
@@ -97,9 +97,9 @@ class BufferSlice(ObjectGeneric):
                     report_error("Negative index is not allowed during buffer access", span)
             elif isinstance(index, PrimExpr):
                 element_dtype = index.dtype.split("x", maxsplit=1)[0]
-                if element_dtype != "int32":
+                if element_dtype[:3] != "int":
                     report_error(
-                        "index expected an int32 type PrimExpr but got " + str(index.dtype),
+                        "index expected an integer type PrimExpr but got " + str(index.dtype),
                         index.span,
                     )
             else:

--- a/python/tvm/script/tir/special_stmt.py
+++ b/python/tvm/script/tir/special_stmt.py
@@ -486,7 +486,6 @@ class BlockAxis(SpecialStmt):
         if var_name in [iter_var.var.name for iter_var in block_scope.iter_vars]:
             self.context.report_error("Duplicate block axis " + var_name, self.node.span)
 
-        block_var = tvm.tir.Var(var_name, dtype="int32")
         dom = tvm.runtime.convert(dom)
         if isinstance(dom, PrimExpr):
             dom = tvm.ir.Range(dom)
@@ -497,6 +496,7 @@ class BlockAxis(SpecialStmt):
                 f"Block axis domain expected PrimExpr or Range, but got {type(dom)}",
                 self.node.span,
             )
+        block_var = tvm.tir.Var(var_name, dtype=dom.extent.dtype)
         value = tvm.runtime.convert(value)
         if not isinstance(value, PrimExpr):
             self.context.report_error(

--- a/python/tvm/script/tir/utils.py
+++ b/python/tvm/script/tir/utils.py
@@ -16,11 +16,12 @@
 # under the License.
 """Helper functions in TVM Script Parser"""
 
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from tvm.arith import Analyzer
 from tvm.ir import Range
 from tvm.tir import PrimExpr, BufferRegion
+from tvm.tir.expr import IntImm
 from .node import BufferSlice
 
 
@@ -44,8 +45,8 @@ def buffer_slice_to_region(
     """
     region: List[Range] = []
     for s in buffer_slice.slices:
-        start: Union[PrimExpr, int] = s.start
-        extent: Union[PrimExpr, int] = 1 if s.stop is None else s.stop - s.start
+        start = s.start if isinstance(s.start, PrimExpr) else IntImm("int32", s.start)
+        extent = IntImm(start.dtype, 1) if s.stop is None else s.stop - s.start
         if not analyzer:
             analyzer = Analyzer()
         if isinstance(extent, PrimExpr):

--- a/src/tir/ir/expr.cc
+++ b/src/tir/ir/expr.cc
@@ -147,6 +147,10 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
 IterVar::IterVar(Range dom, Var var, IterVarType t, String thread_tag, Span span) {
   ObjectPtr<IterVarNode> n = make_object<IterVarNode>();
   if (dom.defined() && dom->extent.defined()) {
+    CHECK(dom->extent.dtype().is_int())
+        << "The dtype of the domain of an IterVar must be an integer type. However, the domain's "
+           "dtype is "
+        << dom->extent.dtype();
     CHECK_EQ(dom->extent.dtype(), var.dtype())
         << "The dtype of the extent of an IterVar (" << dom->extent.dtype()
         << ") must match its associated Var's dtype (" << var.dtype() << ")";

--- a/tests/python/unittest/test_tvmscript_error_report.py
+++ b/tests/python/unittest/test_tvmscript_error_report.py
@@ -21,8 +21,6 @@ import tvm
 from tvm import tir
 from tvm.testing import check_error
 from tvm.script import tir as T
-from tvm.ir.diagnostics import override_renderer
-import inspect
 
 
 def buffer_bind_missing_args(a: T.handle) -> None:
@@ -627,6 +625,15 @@ def floor_dtype(h: T.handle):
 
 def test_floor_dtype():
     check_error(floor_dtype, 3)
+
+
+def non_integer_typed_block_iter():
+    with T.block():
+        i = T.axis.S(0.1, 0.1)  # error IterVar requires an integer dtype
+
+
+def test_non_integer_typed_block_iter():
+    check_error(non_integer_typed_block_iter, 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR cherry-picks the fix of TVMScript parser for `int64`. See https://github.com/apache/tvm/pull/10789 for more details.

