### PR TITLE
[REFACTOR] Improve FoldConstant

### DIFF
--- a/include/tvm/relax/block_builder.h
+++ b/include/tvm/relax/block_builder.h
@@ -119,8 +119,9 @@ class BlockBuilderNode : public Object {
    * \brief Lookup a var in the binding table \p binding_table_.
    * \param var The input var.
    * \return The Expr bound to the input \p var.
+   * \note For function parameters, this function returns NullOpt.
    */
-  Expr LookupBinding(const Var& var);
+  Optional<Expr> LookupBinding(const Var& var);
 
   /*!
    * \brief Check if two shape expressions can be proven equal at compile time.

--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -224,13 +224,15 @@ class MatchShapeNode : public BindingNode {
   }
 
   bool SEqualReduce(const MatchShapeNode* other, SEqualReducer equal) const {
-    return equal(value, other->value) && equal(pattern, other->pattern) &&
+    // NOTE: pattern can contain ShapeExpr which defines the vars
+    return equal(value, other->value) && equal.DefEqual(pattern, other->pattern) &&
            equal.DefEqual(var, other->var);
   }
 
   void SHashReduce(SHashReducer hash_reduce) const {
+    // NOTE: pattern can contain ShapeExpr which defines the vars
     hash_reduce(value);
-    hash_reduce(pattern);
+    hash_reduce.DefHash(pattern);
     hash_reduce.DefHash(var);
   }
 

--- a/include/tvm/relax/expr_functor.h
+++ b/include/tvm/relax/expr_functor.h
@@ -275,8 +275,9 @@ class ExprMutator : public ExprFunctor<Expr(const Expr&)> {
    * \brief Look up the value bound to a variable.
    * \param var The var to be looked up.
    * \return The value bound to the input \p var.
+   * \note For function parameters, this function returns NullOpt.
    */
-  Expr LookupBinding(const Var& var);
+  Optional<Expr> LookupBinding(const Var& var);
 
   /*!
    * \brief Post-order rewrite a node and normalize.
@@ -301,8 +302,6 @@ class ExprMutator : public ExprFunctor<Expr(const Expr&)> {
 
   /*! \brief Remap a var to a new var in use-site. */
   std::unordered_map<Id, Var, ObjectPtrHash, ObjectPtrEqual> var_remap_;
-  
-  
 };
 
 }  // namespace relax

--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -117,11 +117,14 @@ TVM_DLL Pass FoldConstant();
 TVM_DLL Pass FuseOps(int fuse_opt_level = -1);
 
 /*!
- * \brief Bind params of main function of the module to constant tensors.
+ * \brief Bind params of function of the module to constant tensors.
+ *
+ * \param func_name The name of the function to bind parameters.
+ * \param params The parameters to bind.
  *
  * \return The Pass.
  */
- TVM_DLL Pass BindParams(Map<String, runtime::NDArray> params);
+TVM_DLL Pass BindParams(String name, Map<String, runtime::NDArray> params);
 
 }  // namespace transform
 }  // namespace relax

--- a/python/tvm/ir/module.py
+++ b/python/tvm/ir/module.py
@@ -284,9 +284,7 @@ class IRModule(Node):
         script : str
             The TVM Script of the IRModule
         """
-        return tvm._ffi.get_global_func("script.AsTVMScript")(
-            self, tir_prefix, show_meta
-        )  # type: ignore
+        return tvm._ffi.get_global_func("script.AsTVMScript")(self, tir_prefix, show_meta)  # type: ignore
 
     def get_attr(self, attr_key):
         """Get the IRModule attribute.

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -119,6 +119,7 @@ def MetaScheduleApplyHistoryBest(
     """
     return _ffi_api.MetaScheduleApplyHistoryBest(database, target)
 
+
 def AnnotateTIROpPattern() -> tvm.ir.transform.Pass:
     """Annotate Op Pattern Kind for TIR functions
 
@@ -127,6 +128,7 @@ def AnnotateTIROpPattern() -> tvm.ir.transform.Pass:
     ret: tvm.ir.transform.Pass
     """
     return _ffi_api.AnnotateTIROpPattern()
+
 
 def LayoutRewrite() -> tvm.ir.transform.Pass:
     """Layout Rewrite
@@ -137,6 +139,7 @@ def LayoutRewrite() -> tvm.ir.transform.Pass:
     """
     return _ffi_api.LayoutRewrite()
 
+
 def FoldConstant() -> tvm.ir.transform.Pass:
     """Fold Constant
 
@@ -145,6 +148,7 @@ def FoldConstant() -> tvm.ir.transform.Pass:
     ret: tvm.ir.transform.Pass
     """
     return _ffi_api.FoldConstant()
+
 
 def FuseOps(fuse_opt_level=-1) -> tvm.ir.transform.Pass:
     """Fuse operators in an expr to a larger operator according to some rules.
@@ -162,11 +166,16 @@ def FuseOps(fuse_opt_level=-1) -> tvm.ir.transform.Pass:
     """
     return _ffi_api.FuseOps(fuse_opt_level)
 
-def BindParams(params) -> tvm.ir.transform.Pass:
+
+def BindParams(func_name, params) -> tvm.ir.transform.Pass:
     """Bind params of main function of the module to constant tensors.
 
     Parameters
     ----------
+
+    func_name: str
+        The function name to be bound
+
     params : dict from str to ndarray
         The map from param name to constant tensors.
 
@@ -174,4 +183,4 @@ def BindParams(params) -> tvm.ir.transform.Pass:
     -------
     ret: tvm.ir.transform.Pass
     """
-    return _ffi_api.BindParams(params)
+    return _ffi_api.BindParams(func_name, params)

--- a/src/printer/text_printer.h
+++ b/src/printer/text_printer.h
@@ -356,6 +356,9 @@ class RelaxScriptPrinter : public relax::IRFunctor<Doc(const ObjectRef&)>,
     RelaxScriptPrinter* parent_;
   };
 };
+
+String AsRelaxScript(const ObjectRef& mod, bool show_meta_data);
+
 }  // namespace relax
 }  // namespace tvm
 

--- a/src/printer/tvmscript_printer.cc
+++ b/src/printer/tvmscript_printer.cc
@@ -1821,6 +1821,14 @@ Doc TVMScriptPrinterWithDiagnostic::PrintLoop(const For& loop) {
 }
 
 String AsTVMScript(const ObjectRef& mod, const String& tir_prefix, bool show_meta) {
+  // Temporary redirect possibly relax related printing to relax script
+  // TODO(tvm-team): make relax script printer handle all possible cases and
+  // make that as a default of TVMScript printer
+  if (mod->IsInstance<IRModuleNode>() || mod->IsInstance<relax::FunctionNode>()) {
+    // TODO(tvm-team) support tir_prefix in relax printer
+    return relax::AsRelaxScript(mod, show_meta);
+  }
+
   ICHECK(mod->IsInstance<PrimFuncNode>() || mod->IsInstance<IRModuleNode>());
   Doc doc;
   doc << TVMScriptPrinter::PrintHeader(tir_prefix)

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -480,12 +480,9 @@ Var BlockBuilderNode::EmitOutput(const VarBinding& binding) {
   return binding->var;
 }
 
-Expr BlockBuilderNode::LookupBinding(const Var& var) {
+Optional<Expr> BlockBuilderNode::LookupBinding(const Var& var) {
   auto it = binding_table_.find(var->vid);
-  if (it == binding_table_.end()) {
-    this->diag_ctx_.EmitFatal(Diagnostic::Error(var->span)
-                              << "The var to be looked up is not in the binding table.");
-  }
+  if (it == binding_table_.end()) return NullOpt;
   return it->second;
 }
 

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -557,7 +557,7 @@ Expr ExprMutator::VisitWithNewScope(const Expr& expr) {
   return ret;
 }
 
-Expr ExprMutator::LookupBinding(const Var& var) { return builder_->LookupBinding(var); }
+Optional<Expr> ExprMutator::LookupBinding(const Var& var) { return builder_->LookupBinding(var); }
 
 Var ExprMutator::WithShapeAndType(Var var, Optional<ObjectRef> shape, Type type) {
   // shape/type changes if it goes from defined -> undefined or the other way, hence xor

--- a/src/relax/transform/fma_rewrite.cc
+++ b/src/relax/transform/fma_rewrite.cc
@@ -54,7 +54,7 @@ class EwiseFMARewriter : public ExprMutator {
     if (call->op == add_op) {
       // NOTE: assumes df block is completely SSA
       // FIXME(@altanh, @yuchen): this will crash if args[0] isn't a Var
-      Expr value = LookupBinding(Downcast<Var>(call->args[0]));
+      Optional<Expr> value = LookupBinding(Downcast<Var>(call->args[0]));
       const CallNode* mul = value.as<CallNode>();
       if (mul && mul->op == multiply_op) {
         Call fma_call = Call(ewise_fma_op, {mul->args[0], mul->args[1], call->args[1]}, {}, {});

--- a/src/relax/transform/fold_constant.cc
+++ b/src/relax/transform/fold_constant.cc
@@ -18,100 +18,147 @@
  */
 
 #include <tvm/driver/driver_api.h>
+#include <tvm/ir/function.h>
 #include <tvm/relax/attrs/memory.h>
 #include <tvm/relax/expr_functor.h>
 #include <tvm/relax/transform.h>
 #include <tvm/relax/type.h>
-#include <tvm/relay/interpreter.h>
+#include <tvm/tir/function.h>
 #include <tvm/tir/op.h>
 
 namespace tvm {
 namespace relax {
 
-/*!
- * \brief Returns whether \p expr is a literal \p Constant,
- */
-bool IsSimpleConstant(const Expr& expr) { return expr->IsInstance<relay::ConstantNode>(); }
-
 class ConstantFolder : public ExprMutator {
-  Expr ConstEvaluateTIR(GlobalVar tir_f_var, const Array<Expr>& args, ShapeExpr shape) {
-    auto tir_f = module_->functions.Get(tir_f_var).value();
-    runtime::Module module;
-    if (func_build_cache_.count(tir_f)) {
-      module = func_build_cache_.Get(tir_f).value();
+ public:
+  ConstantFolder(IRModule ctx_module) : ctx_module_(ctx_module) {}
+
+ private:
+  /*!
+   * \brief Pattern match expr to a constant shape and get runtime shape tuple from it.
+   * \return The runtime shape tuple, or nullopt if it is not a constant shape.
+   */
+  static Optional<runtime::ShapeTuple> MatchConstShape(const Expr& expr) {
+    if (auto* shape = expr.as<ShapeExprNode>()) {
+      std::vector<int64_t> shape_values;
+      for (const auto v : shape->values) {
+        if (auto* ptr = v.as<IntImmNode>()) {
+          shape_values.push_back(ptr->value);
+        } else {
+          return NullOpt;
+        }
+      }
+      return runtime::ShapeTuple(shape_values.begin(), shape_values.end());
     } else {
-      module = build(LowerPrimFunc(Downcast<tir::PrimFunc>(tir_f), "tir_function"),
-                     eval_cpu_target_, eval_cpu_target_);
-      func_build_cache_.Set(tir_f, module);
+      return NullOpt;
     }
-    TVMRetValue ret;
-
-    //    Array<ObjectRef> args_for_tir = {args.begin(), args.end()};
-    std::vector<runtime::NDArray> args_for_tir;
-    for (auto arg : args) {
-      args_for_tir.push_back(Downcast<relay::Constant>(arg)->data);
-    }
-
-    int kArraySize = args_for_tir.size();
-    TVMValue values[kArraySize + 1];
-    int type_codes[kArraySize + 1];
-
-    DLDevice dev = {DLDeviceType::kDLCPU, 0};
-    std::vector<int64_t> shape_values;
-    for (const auto v : shape->values) {
-      shape_values.push_back(v.as<IntImmNode>()->value);
-    }
-
-    runtime::ShapeTuple shape_tuple{shape_values.begin(), shape_values.end()};
-    auto ret_tensor = runtime::NDArray::Empty(shape_tuple, DataType::Float(32), dev);
-    args_for_tir.push_back(ret_tensor);
-    for (int i = 0; i < static_cast<int>(args_for_tir.size()); i++) {
-      runtime::TVMArgsSetter(values, type_codes)(i, args_for_tir[i]);
-    }
-    module.GetFunction("tir_function")
-        .CallPacked(TVMArgs(values, type_codes, args_for_tir.size()), &ret);
-    return Constant(Downcast<runtime::NDArray>(ObjectRef(ret_tensor)));
   }
 
- public:
-  ConstantFolder(IRModule module) : module_(module) {}
-
-  Expr ForwardBinding(Expr e) {
-    if (const auto* v = e.as<VarNode>()) {
-      // check that the var is not the input param, otherwise the function will crash
-      if (visited_varbinding.count(v)) {
-        return LookupBinding(GetRef<Var>(v));
+  /*!
+   * \brief Pattern match op to constant array arguments.
+   * \return The constant array arguments, or nullopt if match fails.o
+   */
+  static Optional<Array<runtime::NDArray>> MatchConstArrayArgs(const Array<Expr>& args) {
+    Array<runtime::NDArray> res;
+    for (auto arg : args) {
+      if (auto* ptr = arg.as<relay::ConstantNode>()) {
+        res.push_back(ptr->data);
+      } else {
+        return NullOpt;
       }
     }
-    return e;
+    return res;
+  }
+
+  /*!
+   * \brief Pattern match op to a TIR function and look it up.
+   * \return The TIR function, or nullopt if patter match fails.
+   */
+  Optional<tir::PrimFunc> MatchPrimFunc(const Expr& op) {
+    if (auto* ptr = op.as<GlobalVarNode>()) {
+      // NOTE: as check works for nullptr(returns null)
+      Optional<BaseFunc> base_func = ctx_module_->functions.Get(GetRef<GlobalVar>(ptr));
+      if (auto* pfunc = base_func.as<tir::PrimFuncNode>()) {
+        return GetRef<tir::PrimFunc>(pfunc);
+      }
+    }
+    return NullOpt;
+  }
+
+  /*!
+   * \brief Get a cached build version of func
+   * \return The cached func, nullopt if func cannot be built.
+   */
+  Optional<PackedFunc> GetCachedBuild(tir::PrimFunc func) {
+    // TODO(tvm-team): consider another way of bulk extract and build PrimFunc once
+    // would be helpful for future cases where PrimFunc recursively call into each other
+    Target eval_cpu_target{"llvm"};
+
+    auto it = func_build_cache_.find(func);
+    if (it != func_build_cache_.end()) {
+      return it->second;
+    }
+    Optional<PackedFunc> build_func = NullOpt;
+
+    try {
+      runtime::Module rt_module =
+          build(LowerPrimFunc(func, "tir_function"), eval_cpu_target, eval_cpu_target);
+      build_func = rt_module.GetFunction("tir_function");
+    } catch (const tvm::Error& err) {
+      // build failure may happen in which case we skip
+      DLOG(WARNING) << "Build failure for function " << func;
+    }
+    func_build_cache_[func] = build_func;
+    return build_func;
+  }
+
+  // Try constant evaluate the function call
+  // if failed return NullOpt
+  Optional<Expr> ConstEvaluateCallTIR(tir::PrimFunc tir_func, Array<runtime::NDArray> arr_args,
+                                      runtime::ShapeTuple shape) {
+    // obtain function from the cache.
+    Optional<PackedFunc> func = GetCachedBuild(tir_func);
+    if (!func) return NullOpt;
+
+    std::vector<TVMValue> values(arr_args.size() + 1);
+    std::vector<int> type_codes(arr_args.size() + 1);
+
+    DLDevice cpu_dev = {DLDeviceType::kDLCPU, 0};
+    runtime::NDArray ret_tensor = runtime::NDArray::Empty(shape, DataType::Float(32), cpu_dev);
+
+    // avoid set rvalue ref which get de-allocated later, store args in a vector
+    // where temp_args[i] are lvalue ref that is stable
+    std::vector<runtime::NDArray> temp_args(arr_args.begin(), arr_args.end());
+
+    size_t arg_offset = 0;
+    for (; arg_offset < arr_args.size(); ++arg_offset) {
+      runtime::TVMArgsSetter(values.data(), type_codes.data())(arg_offset, temp_args[arg_offset]);
+    }
+    // set return value
+    runtime::TVMArgsSetter(values.data(), type_codes.data())(arg_offset++, ret_tensor);
+
+    TVMRetValue ret;
+    // invoke
+    func.value().CallPacked(TVMArgs(values.data(), type_codes.data(), values.size()), &ret);
+    return Constant(ret_tensor);
   }
 
   Expr VisitCallTIR(Call call) {
-    Array<Expr> args;
-    Expr op = call->op;
-    if (call->args[1].as<TupleNode>()) {
-      args = Downcast<Tuple>(call->args[1])->fields;
-    } else {
-      args.push_back(call->args[1]);
+    // call_tir needs to have at least three arguments
+    ICHECK_GE(call->args.size(), 3);
+    Optional<tir::PrimFunc> func = MatchPrimFunc(call->args[0]);
+    ICHECK(call->args[1].as<TupleNode>()) << "call_tir.args[1] requires to be Tuple";
+    Optional<Array<runtime::NDArray>> arr_args =
+        MatchConstArrayArgs(call->args[1].as<TupleNode>()->fields);
+    Optional<runtime::ShapeTuple> shape = MatchConstShape(call->args[2]);
+
+    // Pattern 0: call constant function, const argument with const shape.
+    if (func && arr_args && shape) {
+      // value_or will return value if it is not null, otherwise return or
+      return ConstEvaluateCallTIR(func.value(), arr_args.value(), shape.value()).value_or(call);
     }
-    op = call->args[0];
-    Array<Expr> processed_args;
-    for (const auto& e : args) {
-      processed_args.push_back(ForwardBinding(e));
-    }
-    if (!std::all_of(processed_args.begin(), processed_args.end(), IsSimpleConstant)) {
-      // At least one non-constant argument.
-      return std::move(call);
-    }
-    // During evaluation we have obviously lost all on_device annotations. However any
-    // on_device wrapping this call will be left in place.
-    try {
-      auto fold_result = ConstEvaluateTIR(Downcast<GlobalVar>(op), processed_args,
-                                          Downcast<ShapeExpr>(call->args[2]));
-      return fold_result;
-    } catch (tvm::Error& error) {
-      return std::move(call);
-    }
+    // TODO(hongyi): support const-fole tuple outputs
+    return std::move(call);
   }
 
   Expr VisitExpr_(const CallNode* call) override {
@@ -126,51 +173,42 @@ class ConstantFolder : public ExprMutator {
     }
   }
 
-  void VisitBinding_(const VarBindingNode* binding) final {
-    visited_varbinding.insert(binding->var.get());
-    ExprMutator::VisitBinding_(binding);
-  }
-
   Expr VisitExpr_(const DataflowVarNode* op) final {
-    Var post_visit = Downcast<Var>(VisitExprPostOrder_(op));
-    if (visited_varbinding.count(op)) {
-      Expr expr = LookupBinding(GetRef<Var>(op));
-      if (expr->IsInstance<relay::ConstantNode>()) {
-        return expr;
-      }
+    Optional<Expr> opt = LookupBinding(GetRef<Var>(op));
+    // NOTE: opt can be nullptr, in which case opt is nullptr
+    // as check checks if opt is not null and is instance of constant
+    if (opt.as<relay::ConstantNode>()) {
+      return opt.value();
+    } else {
+      return ExprMutator::VisitExpr_(op);
     }
-    return post_visit;
   }
-  
+
   Expr VisitExpr_(const VarNode* op) final {
-    Var post_visit = Downcast<Var>(VisitExprPostOrder_(op));
-    if (visited_varbinding.count(op)) {
-      Expr expr = LookupBinding(GetRef<Var>(op));
-      if (expr->IsInstance<relay::ConstantNode>()) {
-        return expr;
-      }
+    Optional<Expr> opt = LookupBinding(GetRef<Var>(op));
+    // NOTE: opt can be nullptr, in which case opt is nullptr
+    // as check checks if opt is not null and is instance of constant
+    if (opt.as<relay::ConstantNode>()) {
+      return opt.value();
+    } else {
+      return ExprMutator::VisitExpr_(op);
     }
-    return post_visit;
   }
 
-  IRModule module_;
-  Target eval_cpu_target_{"llvm"};
-  Device eval_cpu_dev_{kDLCPU, /*device_id=*/0};
-  std::unordered_set<const VarNode*> visited_varbinding;
-  Map<BaseFunc, runtime::Module> func_build_cache_;
+  // the context module to lookup functions
+  IRModule ctx_module_;
+  // cache for function build, via structural equality
+  std::unordered_map<tir::PrimFunc, Optional<runtime::PackedFunc>, StructuralHash, StructuralEqual>
+      func_build_cache_;
 };
-
-Expr FoldConstant(const IRModule& m, const Expr& e) {
-  Expr expr = ConstantFolder(m).VisitExpr(e);
-  return expr;
-}
 
 namespace transform {
 
 Pass FoldConstant() {
   runtime::TypedPackedFunc<Function(Function, IRModule, PassContext)> pass_func =
       [=](Function f, IRModule m, PassContext pc) {
-        return Downcast<Function>(FoldConstant(m, f));
+        ConstantFolder folder(m);
+        return Downcast<Function>(folder(f));
       };
   return CreateFunctionPass(pass_func, 0, "FoldConstant", {});
 }

--- a/src/relax/transform/fold_constant.cc
+++ b/src/relax/transform/fold_constant.cc
@@ -157,7 +157,7 @@ class ConstantFolder : public ExprMutator {
       // value_or will return value if it is not null, otherwise return or
       return ConstEvaluateCallTIR(func.value(), arr_args.value(), shape.value()).value_or(call);
     }
-    // TODO(hongyi): support const-fole tuple outputs
+    // TODO(hongyi): support const-fold tuple outputs
     return std::move(call);
   }
 

--- a/tests/python/relax/test_transform_fold_constant.py
+++ b/tests/python/relax/test_transform_fold_constant.py
@@ -28,8 +28,9 @@ from tvm.script import tir as T, relax as R
 
 def check(mod):
     x_tvm = tvm.nd.array(np.ones((16, 16), "float32"))
-    mod = relax.transform.BindParams({"x": x_tvm})(mod)
+    mod = relax.transform.BindParams("main", {"x": x_tvm})(mod)
     mod = relax.transform.FoldConstant()(mod)
+    print(mod.script())
 
     ret = None
 
@@ -42,41 +43,127 @@ def check(mod):
     relax.analysis.post_order_visit(mod["main"], fvisit)
     tvm.testing.assert_allclose(ret.numpy(), x_tvm.numpy())
 
-def test_one_fold():
+
+def gen_mod(mod, name, binding):
+    """Select relax function with name, rename to main and and bind constant.
+
+    Parameters
+    ----------
+    mod: IRModule
+        The input module
+
+    name: str
+        The name of relax function to preserve and rename to main
+
+    binding: Dict[str, array]
+        The const parameter bindings
+    """
+    funcs = {}
+    binding = {k: tvm.nd.array(v) for k, v in binding.items()}
+
+    for k, v in mod.functions.items():
+        if isinstance(v, tvm.relax.Function):
+            if k.name_hint == name:
+                # rename to main
+                gv = tvm.ir.GlobalVar("main")
+                funcs[gv] = tvm.relax.Function(v.params, v.body, v.ret_type, gv)
+        else:
+            funcs[k] = v
+    mod = tvm.IRModule(funcs)
+    return relax.transform.BindParams("main", binding)(mod)
+
+
+def test_one_fold_addone():
+    # put before after in a single module
     @tvm.script.ir_module
     class InputModule:
         @T.prim_func
-        def identity(A: T.Buffer[(16, 16), "float32"], B: T.Buffer[(16, 16), "float32"]) -> None:
+        def addone(A: T.Buffer[(16, 16), "float32"], B: T.Buffer[(16, 16), "float32"]) -> None:
             for i, j in T.grid(16, 16):
-                with T.block("identity"):
+                with T.block("addone"):
                     vi, vj = T.axis.remap("SS", [i, j])
-                    B[vi, vj] = A[vi, vj]
+                    B[vi, vj] = A[vi, vj] + T.float32(1)
 
         @R.function
-        def main(x: Tensor[(16, 16), "float32"]):
-            lv0 = relax.call_tir(identity, (x,), (16, 16), dtype="float32")
+        def before(c0: Tensor[(16, 16), "float32"]):
+            lv0 = relax.call_tir(addone, (c0,), (16, 16), dtype="float32")
             return lv0
 
-    check(InputModule)
+        @R.function
+        def after(c1: Tensor[(16, 16), "float32"]):
+            lv0 = c1
+            return c1
+
+    c0_np = np.arange((16 * 16)).astype("float32").reshape(16, 16)
+    c1_np = c0_np + 1
+    mod_before = gen_mod(InputModule, "before", {"c0": c0_np})
+    mod_after = gen_mod(InputModule, "after", {"c1": c1_np})
+
+    mod_res = relax.transform.FoldConstant()(mod_before)
+    tvm.ir.assert_structural_equal(mod_res, mod_after)
 
 
-def test_two_fold():
+def test_one_fold_transpose():
+    # put before after in a single module
     @tvm.script.ir_module
     class InputModule:
         @T.prim_func
-        def identity(A: T.Buffer[(16, 16), "float32"], B: T.Buffer[(16, 16), "float32"]) -> None:
-            for i, j in T.grid(16, 16):
-                with T.block("identity"):
+        def identity(A: T.Buffer[(2, 3), "float32"], B: T.Buffer[(3, 2), "float32"]) -> None:
+            for i, j in T.grid(3, 2):
+                with T.block("transpose"):
                     vi, vj = T.axis.remap("SS", [i, j])
-                    B[vi, vj] = A[vi, vj]
+                    B[vi, vj] = A[vj, vi]
 
         @R.function
-        def main(x: Tensor[(16, 16), "float32"]):
-            lv0 = relax.call_tir(identity, (x,), (16, 16), dtype="float32")
-            lv1 = relax.call_tir(identity, (lv0,), (16, 16), dtype="float32")
+        def before(c0: Tensor[(2, 3), "float32"]):
+            lv0 = relax.call_tir(identity, (c0,), (3, 2), dtype="float32")
+            return lv0
+
+        @R.function
+        def after(c1: Tensor[(3, 2), "float32"]):
+            lv0 = c1
+            return c1
+
+    c0_np = np.arange(2 * 3).astype("float32").reshape(2, 3)
+    c1_np = c0_np.T
+    mod_before = gen_mod(InputModule, "before", {"c0": c0_np})
+    mod_after = gen_mod(InputModule, "after", {"c1": c1_np})
+
+    mod_res = relax.transform.FoldConstant()(mod_before)
+    tvm.ir.assert_structural_equal(mod_res, mod_after)
+
+
+def test_two_hop_addone():
+    @tvm.script.ir_module
+    class InputModule:
+        @T.prim_func
+        def addone(A: T.Buffer[(2, 2), "float32"], B: T.Buffer[(2, 2), "float32"]) -> None:
+            for i, j in T.grid(2, 2):
+                with T.block("addone"):
+                    vi, vj = T.axis.remap("SS", [i, j])
+                    B[vi, vj] = A[vi, vj] + T.float32(1)
+
+        @R.function
+        def before(c0: Tensor[(2, 2), "float32"]):
+            lv0 = relax.call_tir(addone, (c0,), (2, 2), dtype="float32")
+            lv1 = relax.call_tir(addone, (lv0,), (2, 2), dtype="float32")
             return lv1
 
-    check(InputModule)
+        @R.function
+        def after(c1: Tensor[(2, 2), "float32"], c2: Tensor[(2, 2), "float32"]):
+            lv0 = c1
+            lv1 = c2
+            return c2
+
+    c0_np = np.arange((2 * 2)).astype("float32").reshape(2, 2)
+    c1_np = c0_np + 1
+    c2_np = c1_np + 1
+    mod_before = gen_mod(InputModule, "before", {"c0": c0_np})
+    mod_after = gen_mod(InputModule, "after", {"c1": c1_np, "c2": c2_np})
+
+    mod_res = relax.transform.FoldConstant()(mod_before)
+    tvm.ir.assert_structural_equal(mod_res, mod_after)
+
 
 def test_dataflow_fold():
     @tvm.script.ir_module
@@ -89,35 +176,98 @@ def test_dataflow_fold():
                     B[vi, vj] = A[vi, vj]
 
         @R.function
-        def main(x: Tensor[(16, 16), "float32"]):
+        def before(c0: Tensor[(16, 16), "float32"]):
             with R.dataflow():
-                gv0 = relax.call_tir(identity, (x,), (16, 16), dtype="float32")
+                gv0 = relax.call_tir(identity, (c0,), (16, 16), dtype="float32")
                 R.output(gv0)
             return gv0
 
-    check(InputModule)
+        @R.function
+        def after(c1: Tensor[(16, 16), "float32"]):
+            with R.dataflow():
+                gv0 = c1
+                R.output(gv0)
+            return c1
 
-def test_dynamic_shape():
+    c0_np = np.arange((16 * 16)).astype("float32").reshape(16, 16)
+    c1_np = c0_np
+    mod_before = gen_mod(InputModule, "before", {"c0": c0_np})
+    mod_after = gen_mod(InputModule, "after", {"c1": c1_np})
+    mod_res = relax.transform.FoldConstant()(mod_before)
+    tvm.ir.assert_structural_equal(mod_res, mod_after)
+
+
+def test_fold_mixed_case():
     @tvm.script.ir_module
     class InputModule:
+        # TIR function can handle different cases.
         @T.prim_func
-        def identity(a: T.handle, b: T.handle, m: T.int32, n: T.int32) -> None:
-            A = T.match_buffer(a, (m, n))
-            B = T.match_buffer(b, (m, n))
-            for i, j in T.grid(m, n):
-                with T.block("identity"):
+        def addone(a: T.handle, b: T.handle) -> None:
+            n = T.var("int32")
+            m = T.var("int32")
+            A = T.match_buffer(a, (n, m))
+            B = T.match_buffer(b, (n, m))
+            for i, j in T.grid(n, m):
+                with T.block("addone"):
                     vi, vj = T.axis.remap("SS", [i, j])
-                    B[vi, vj] = A[vi, vj]
+                    B[vi, vj] = A[vi, vj] + T.float32(1)
+
+        @T.prim_func
+        def sub(
+            A: T.Buffer[(16, 16), "float32"],
+            B: T.Buffer[(16, 16), "float32"],
+            C: T.Buffer[(16, 16), "float32"],
+        ) -> None:
+            for i, j in T.grid(16, 16):
+                with T.block("sub"):
+                    vi, vj = T.axis.remap("SS", [i, j])
+                    C[vi, vj] = A[vi, vj] - B[vi, vj]
 
         @R.function
-        def main(x: Tensor[(m, n), "float32"]):
-            lv0 = relax.call_tir(identity, (x, ), (m, n), (m, n), dtype="float32")
-            return lv0
-    check(InputModule)
+        def before(c0: Tensor[(16, 16), "float32"], x: Tensor[(_, _), "float32"]):
+            x0 = R.match_shape(x, (n, m))
+            # this line cannot be folded because n is unknown
+            lv0 = relax.call_tir(addone, (c0,), (n, 16), dtype="float32")
+            # this line can be folded
+            lv1 = relax.call_tir(addone, (c0,), (16, 16), dtype="float32")
+            # this line can be folded because all inputs are const
+            lv2 = relax.call_tir(sub, (c0, lv1), (16, 16), dtype="float32")
+            # this line can not be folded because x's shape is unknown
+            lv3 = relax.call_tir(sub, (lv2, x), (16, 16), dtype="float32")
+            return lv3
+
+        @R.function
+        def after(
+            c0: Tensor[(16, 16), "float32"],
+            c1: Tensor[(16, 16), "float32"],
+            c2: Tensor[(16, 16), "float32"],
+            x: Tensor[(_, _), "float32"],
+        ):
+            x0 = R.match_shape(x, (n, m))
+            # this line cannot be folded because n is unknown
+            lv0 = relax.call_tir(addone, (c0,), (n, 16), dtype="float32")
+            # this line can be folded
+            lv1 = c1
+            # this line can be folded because all inputs are const
+            lv2 = c2
+            # this line can not be folded because x's shape is unknown
+            lv3 = relax.call_tir(sub, (c2, x), (16, 16), dtype="float32")
+            return lv3
+
+    c0_np = np.arange((16 * 16)).astype("float32").reshape(16, 16)
+    c1_np = c0_np + 1
+    c2_np = c0_np - c1_np
+
+    mod_before = gen_mod(InputModule, "before", {"c0": c0_np})
+    mod_after = gen_mod(InputModule, "after", {"c0": c0_np, "c1": c1_np, "c2": c2_np})
+    mod_res = relax.transform.FoldConstant()(mod_before)
+    tvm.ir.assert_structural_equal(mod_res, mod_after)
+
 
 if __name__ == "__main__":
-    test_one_fold()
-    test_two_fold()
+    test_one_fold_addone()
+    test_one_fold_transpose()
+    test_two_hop_addone()
     test_dataflow_fold()
-    # test_dynamic_shape()
-
+    test_dataflow_fold()
+    test_fold_mixed_case()


### PR DESCRIPTION
This PR refactors the FoldConstant to make it more robust with test coverages.
Refactor notes:

- class
  - always mark private, public and other fields
  - public comes before private
  - hide most members via private
  - class member with underscore in the end
- Use structural hash/equal for cache so we can dedup via deep equality
- Use Match and optional pattern to match parts of programs
  - match function return Optional<Type>
  - Use value_or to switch to default case
  - Optional allows deferred checking
- Add ICHECK to ensure invariance of call->args.size() >= 3
- Refactor lookup binding to return optional and remove need of var_bindings
- Localize try-catch into local functions
- Fix coverage patterns of cases that can not be folded:
  - shape is a ShapeExpr but not constant
  - function field is not a PrimFunc or cannot be looked up for some reason
  - tuple output(added a TODO)
- Test-cases:
  - refactored to use struct equal check
  - additional minimum coverage for cases that do not fold
- TODOs:
   - Deadcode elimination after fold constant
   - Tuple output
- Refactor/fix on relax: to be upstreamed
  - Refactor: Update blockbuilder->Lookup to return optional
  - Fix: MatchShape should do DefEqual on pattern, otherwise cannot match n, m
