### PR TITLE
[TIR][BugFix] OpPattern annotation dealing with zero index and zero-dim buffer

### DIFF
--- a/src/relax/transform/annotate_tir_op_pattern.cc
+++ b/src/relax/transform/annotate_tir_op_pattern.cc
@@ -1,44 +1,43 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one
-* or more contributor license agreements.  See the NOTICE file
-* distributed with this work for additional information
-* regarding copyright ownership.  The ASF licenses this file
-* to you under the Apache License, Version 2.0 (the
-* "License"); you may not use this file except in compliance
-* with the License.  You may obtain a copy of the License at
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 /*!
-* \file src/relax/transform/annotate_tir_op_pattern.cc
-* \brief Annotate Op Pattern for TIR functions
-*/
+ * \file src/relax/transform/annotate_tir_op_pattern.cc
+ * \brief Annotate Op Pattern for TIR functions
+ */
 #include <tvm/relax/attrs/memory.h>
 #include <tvm/relax/transform.h>
 #include <tvm/relax/type.h>
 #include <tvm/tir/analysis.h>
+#include <tvm/tir/function.h>
 
-#include "tvm/tir/function.h"
 #include "../../printer/text_printer.h"
 
 namespace tvm {
 namespace relax {
-
 
 IRModule Annotate(IRModule m) {
   Map<GlobalVar, tir::PrimFunc> func_map;
   for (const std::pair<GlobalVar, BaseFunc>& pr : m->functions) {
     if (const auto* f = pr.second.as<tir::PrimFuncNode>()) {
       relay::OpPatternKind kind = AnalyzeOpPatternKind(GetRef<tir::PrimFunc>(f));
-      tir::PrimFunc annotated_func = WithAttr(GetRef<tir::PrimFunc>(f), "op_pattern", Integer(static_cast<int>
-    (kind)));
+      tir::PrimFunc annotated_func =
+          WithAttr(GetRef<tir::PrimFunc>(f), "op_pattern", Integer(static_cast<int>(kind)));
       func_map.Set(pr.first, annotated_func);
     }
   }

--- a/src/tir/schedule/analysis/analysis.cc
+++ b/src/tir/schedule/analysis/analysis.cc
@@ -1937,8 +1937,7 @@ bool CheckBroadcastPattern(const Array<PrimExpr>& store_indices, const BufferLoa
   int ndim_stored_buf = store_indices.size();
 
   for (int i = 0; i < ndim_loaded_buf; ++i) {
-    if (is_const_int(loaded_buf->shape[i], 1) &&
-        is_const_int(is_const_int(buffer_load->indices[i], 0))) {
+    if (is_const_int(loaded_buf->shape[i], 1) && is_const_int(buffer_load->indices[i], 0)) {
       continue;
     }
 

--- a/src/tir/schedule/analysis/analysis.cc
+++ b/src/tir/schedule/analysis/analysis.cc
@@ -2034,7 +2034,9 @@ class PatternKindAnalyzer : public StmtExprVisitor {
   }
 
   void VisitExpr_(const BufferLoadNode* op) final {
-    loads_.push_back(GetRef<BufferLoad>(op));
+    if (op->indices.size() > 0) {
+      loads_.push_back(GetRef<BufferLoad>(op));
+    }
     ExprVisitor::VisitExpr_(op);
   }
 

--- a/src/tir/schedule/analysis/analysis.cc
+++ b/src/tir/schedule/analysis/analysis.cc
@@ -1917,16 +1917,32 @@ bool CheckSameArray(const Array<PrimExpr>& arr1, const Array<PrimExpr>& arr2) {
   return true;
 }
 
-bool CheckElemwisePattern(const Array<PrimExpr>& indices_l, const Array<PrimExpr>& indices_r) {
-  if (indices_l.size() != indices_r.size()) {
-    return false;
-  }
-  int n = indices_l.size();
-  for (int i = 0; i < n; i++) {
-    if (!indices_l[i].same_as(indices_r[i])) {
+bool CheckElemwisePattern(const Array<PrimExpr>& store_indices, const BufferLoad& buffer_load) {
+  const Buffer& loaded_buf = buffer_load->buffer;
+  int ndim_loaded_buf = loaded_buf->shape.size();
+  int ndim_stored_buf = store_indices.size();
+
+  int j = 0;
+  for (int i = 0; i < ndim_stored_buf; ++i, ++j) {
+    while (j < ndim_loaded_buf &&                    //
+           is_const_int(loaded_buf->shape[j], 1) &&  //
+           is_const_int(is_const_int(buffer_load->indices[j], 0))) {
+      ++j;
+    }
+
+    if (j == ndim_loaded_buf || !store_indices[i].same_as(buffer_load->indices[j])) {
       return false;
     }
   }
+
+  while (j < ndim_loaded_buf) {
+    if (!(is_const_int(loaded_buf->shape[j], 1) &&
+          is_const_int(is_const_int(buffer_load->indices[j], 0)))) {
+      return false;
+    }
+    ++j;
+  }
+
   return true;
 }
 
@@ -2036,7 +2052,7 @@ class PatternKindAnalyzer : public StmtExprVisitor {
       index_pair_pattern = relay::kBroadcast;
     } else {
       for (int i = 0; i < static_cast<int>(loads_.size()); ++i) {
-        if (CheckElemwisePattern(store_->indices, loads_[i]->indices)) {
+        if (CheckElemwisePattern(store_->indices, loads_[i])) {
           index_pair_pattern = std::max(index_pair_pattern, relay::kElemWise);
         } else if (CheckBroadcastPattern(store_->indices, loads_[i])) {
           index_pair_pattern = std::max(index_pair_pattern, relay::kBroadcast);

--- a/tests/python/relax/test_transform_annotate_tir_op_pattern.py
+++ b/tests/python/relax/test_transform_annotate_tir_op_pattern.py
@@ -152,5 +152,29 @@ def test_annotate_opkind_bias_add():
     assert new_mod["tir_bias_add"].attrs["op_pattern"] == 1
 
 
+def test_annotate_opkind_add_broadcast_with_unit_shape():
+    @tvm.script.ir_module
+    class InputModule:
+        @T.prim_func
+        def add_with_unit_dim_len_broadcast(
+            rxplaceholder_2: T.Buffer[(1, 64, 112, 112), "float32"],
+            rxplaceholder_3: T.Buffer[(64, 1, 1), "float32"],
+            T_add_1: T.Buffer[(1, 64, 112, 112), "float32"],
+        ) -> None:
+            T.func_attr({"global_symbol": "add5", "tir.noalias": True})
+            for i0, i1, i2, i3 in T.grid(1, 64, 112, 112):
+                with T.block("T_add"):
+                    ax0, ax1, ax2, ax3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
+                    T.reads(rxplaceholder_2[ax0, ax1, ax2, ax3], rxplaceholder_3[ax1, 0, 0])
+                    T.writes(T_add_1[ax0, ax1, ax2, ax3])
+                    T_add_1[ax0, ax1, ax2, ax3] = (
+                        rxplaceholder_2[ax0, ax1, ax2, ax3] + rxplaceholder_3[ax1, 0, 0]
+                    )
+
+    mod = InputModule
+    new_mod = relax.transform.AnnotateTIROpPattern()(mod)
+    assert new_mod["add_with_unit_dim_len_broadcast"].attrs["op_pattern"] == 1
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/python/relax/test_transform_annotate_tir_op_pattern.py
+++ b/tests/python/relax/test_transform_annotate_tir_op_pattern.py
@@ -187,30 +187,6 @@ def test_annotate_opkind_add_broadcast_with_unit_shape():
     )
 
 
-def test_annotate_opkind_add_element_wise_with_unit_shape():
-    @tvm.script.ir_module
-    class InputModule:
-        @T.prim_func
-        def add_with_unit_dim_len_element_wise(
-            A: T.Buffer[(64, 112, 112), "float32"],
-            B: T.Buffer[(1, 64, 112, 112, 1, 1), "float32"],
-            C: T.Buffer[(64, 112, 112), "float32"],
-        ) -> None:
-            T.func_attr({"global_symbol": "add5", "tir.noalias": True})
-            for i0, i1, i2 in T.grid(64, 112, 112):
-                with T.block("T_add"):
-                    ax0, ax1, ax2 = T.axis.remap("SSS", [i0, i1, i2])
-                    T.reads(A[ax0, ax1, ax2], B[0, ax0, ax1, ax2, 0, 0])
-                    T.writes(C[ax0, ax1, ax2])
-                    C[ax0, ax1, ax2] = A[ax0, ax1, ax2] + B[0, ax0, ax1, ax2, 0, 0]
-
-    mod = InputModule
-    new_mod = relax.transform.AnnotateTIROpPattern()(mod)
-    assert (
-        new_mod["add_with_unit_dim_len_element_wise"].attrs["op_pattern"] == OpPatternKind.kElemWise
-    )
-
-
 def test_annotate_opkind_add_zero_dim_element_wise():
     @tvm.script.ir_module
     class InputModule:


### PR DESCRIPTION
This PR fixes some known bugs on OpPattern annotation with unit tests:
* skip the dimensions of the loaded buffers where the dimension length is 1 and the load-index on that dimension is 0;
* treat zero-dim buffer load as element-wise, instead of broadcast.

cc @jinhongyii @Hzfengsy 