### PR TITLE
[E2E] Update tuning script / Fix Relay-translator / Fix Layout-Transform

### DIFF
--- a/python/tvm/relax/testing/relay_translator.py
+++ b/python/tvm/relax/testing/relay_translator.py
@@ -243,7 +243,7 @@ def from_relay(func: relay.Function) -> IRModule:
             var_map[node] = var
         elif isinstance(node, relay.Constant):
             # fill the shape and checked_type fields of the Constant
-            new_constant = relay.Constant(node.data)
+            new_constant = relax.BlockBuilder.current().normalize(relay.Constant(node.data))
             var_map[node] = new_constant
         elif isinstance(node, relay.Tuple):
             new_fields = []

--- a/tests/python/relax/run_relax_ms.sh
+++ b/tests/python/relax/run_relax_ms.sh
@@ -28,7 +28,7 @@ run () {
         --rpc-port "$RPC_PORT"                              \
         --rpc-key "$RPC_KEY"                                \
         --tune-model $tune_model                            \
-        --layout $layout
+        --layout $layout                                    \
         2>&1 | tee "$log_dir/$name.log"
 }
 


### PR DESCRIPTION
This PR does three things:
* We improve our tuning script so that we have an all-close assertion at the end of both executions. Besides, the RPC running part becomes more concise.
* Fix a bug in Relay-translator so that a Constant will be normalized first, in order to have the correct checked-type/shape, before put into the variable mapping.
* Fix a bug in Layout-Transform which didn’t wrap the Call-TIR arguments with a Tuple.

cc @Hzfengsy @jinhongyii 